### PR TITLE
Fix warning on kubectl-ssh

### DIFF
--- a/kubectl-ssh
+++ b/kubectl-ssh
@@ -70,9 +70,9 @@ ssh_pod() {
     echo "Pod name must be specified."
     exit 1
   fi
-  kubectl exec -it "$@" bash || (
+  kubectl exec -it "$@" -- bash || (
     echo "Running bash in pod failed; trying with sh"
-    kubectl exec -it "$@" sh
+    kubectl exec -it "$@" -- sh
   )
 }
 


### PR DESCRIPTION
When I run kubectl-ssh I get the following warning:

    kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.

This PR fixes this warning.