### PR TITLE
optimize sh/bash invocation in kubectl-ssh

### DIFF
--- a/kubectl-ssh
+++ b/kubectl-ssh
@@ -70,10 +70,8 @@ ssh_pod() {
     echo "Pod name must be specified."
     exit 1
   fi
-  kubectl exec -it "$@" bash || (
-    echo "Running bash in pod failed; trying with sh"
-    kubectl exec -it "$@" sh
-  )
+  # Use sh as a default and switch to bash if it's available
+  kubectl exec -it "$@" -- sh -c 'exec "$( command -v bash || echo sh )"'
 }
 
 print_usage() {


### PR DESCRIPTION
Run sh as a default shell. Check if bash is available and switch on it.