### PR TITLE
fix: support k exec command with options

### DIFF
--- a/kubectl-ssh
+++ b/kubectl-ssh
@@ -72,7 +72,7 @@ EOF
   if [ -z "$command" ]; then
     kubectl attach -n "$ns" -it "$pod" -c ssh-node "$@"
   else
-    kubectl exec -n "$ns" -it "$pod" ssh-node -- "$command"
+    kubectl exec -n "$ns" -it "$pod" ssh-node -- $command
   fi
 }
 


### PR DESCRIPTION
Fix for issue https://github.com/luksa/kubectl-plugins/issues/10

Result:

```
$ kubectl ssh node my-node 'ls -l'
Created pod/ssh-node-4txnt
Waiting for container to start...
total 52
drwxr-xr-x    2 root     root         12288 Sep 26 21:31 bin
drwxr-xr-x   12 root     root          2880 Nov 21 01:15 dev
drwxr-xr-x    1 root     root          4096 Nov 21 01:15 etc
drwxr-xr-x    2 nobody   nobody        4096 Sep 26 21:31 home
drwxr-xr-x    1 root     root          4096 Nov 20 23:39 host
drwxr-xr-x    2 root     root          4096 Sep 26 21:31 lib
lrwxrwxrwx    1 root     root             3 Sep 26 21:31 lib64 -> lib
dr-xr-xr-x  620 root     root             0 Nov 21 01:15 proc
-rw-r--r--    1 root     root             5 Nov 21 01:15 product_name
-rw-r--r--    1 root     root            37 Nov 21 01:15 product_uuid
drwx------    2 root     root          4096 Sep 26 21:31 root
dr-xr-xr-x   13 root     root             0 Nov 20 23:40 sys
drwxrwxrwt    2 root     root          4096 Sep 26 21:31 tmp
drwxr-xr-x    4 root     root          4096 Sep 26 21:31 usr
drwxr-xr-x    1 root     root          4096 Nov 21 01:15 var
pod "ssh-node-4txnt" deleted
$ 
```